### PR TITLE
Endpoint for saving players score

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = {
+  "config": path.resolve('./src/server/config', 'config.json'),
+  "models-path": path.resolve('./src/server/models'),
+  "seeders-path": path.resolve('./src/server/seeders'),
+  "migrations-path": path.resolve('./src/server/migrations')
+};

--- a/package.json
+++ b/package.json
@@ -71,9 +71,14 @@
     "webpack-serve": "^1.0.2"
   },
   "dependencies": {
+    "body-parser": "^1.18.3",
     "express": "^4.16.3",
     "gsap": "^2.0.1",
+    "morgan": "^1.9.0",
+    "pg": "^7.4.3",
+    "pg-hstore": "^2.3.2",
     "pixi-sound": "^2.0.2",
-    "pixi.js": "^4.8.0"
+    "pixi.js": "^4.8.0",
+    "sequelize": "^4.38.0"
   }
 }

--- a/src/server/config/config.json
+++ b/src/server/config/config.json
@@ -1,0 +1,26 @@
+{
+  "development": {
+    "username": "postgres",
+    "password": "postgres",
+    "database": "tetro",
+    "host": "127.0.0.1",
+    "port": 5432,
+    "dialect": "postgres"
+  },
+  "test": {
+    "username": "postgres",
+    "password": "postgres",
+    "database": "tetro",
+    "host": "127.0.0.1",
+    "port": 5432,
+    "dialect": "postgres"
+  },
+  "production": {
+    "username": "postgres",
+    "password": "postgres",
+    "database": "tetro",
+    "host": "127.0.0.1",
+    "port": 5432,
+    "dialect": "postgres"
+  }
+}

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -1,0 +1,5 @@
+const scores = require('./scores');
+
+module.exports = {
+  scores,
+};

--- a/src/server/controllers/scores.js
+++ b/src/server/controllers/scores.js
@@ -1,0 +1,19 @@
+const { Score } = require('../models');
+
+module.exports = {
+  create(req, res) {
+    return Score
+      .create({
+        player: req.body.player,
+        score: req.body.score,
+      })
+      .then(todo => res.status(201).send(todo))
+      .catch(error => res.status(400).send(error));
+  },
+  list(req, res) {
+    return Score
+      .all()
+      .then(todos => res.status(200).send(todos))
+      .catch(error => res.status(400).send(error));
+  },
+};

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,12 +1,20 @@
 const path = require('path');
 const express = require('express');
+const logger = require('morgan');
 const http = require('http');
+const bodyParser = require('body-parser');
 
 const app = express();
 const server = http.createServer(app);
 const PORT = process.env.PORT || 9000;
 
 app.use(express.static(path.join(__dirname, '../../public')));
+app.use(logger('dev'));
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+
+require('./routes')(app);
+
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '../../public', 'index.html'));
 });
@@ -14,3 +22,5 @@ app.get('*', (req, res) => {
 server.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}.`);
 });
+
+module.exports = app;

--- a/src/server/migrations/20180621172842-create-score.js
+++ b/src/server/migrations/20180621172842-create-score.js
@@ -1,0 +1,30 @@
+
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Scores', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    player: {
+      allowNull: false,
+      type: Sequelize.STRING
+    },
+    score: {
+      allowNull: false,
+      type: Sequelize.INTEGER
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface =>
+    queryInterface.dropTable('Scores'),
+};

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -1,0 +1,38 @@
+
+
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+
+const basename = path.basename(__filename);
+const env = process.env.NODE_ENV || 'development';
+const config = require('../config/config.json')[env];
+
+const db = {};
+
+let sequelize = {};
+
+if (config.use_env_variable) {
+  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+} else {
+  sequelize = new Sequelize(config.database, config.username, config.password, config);
+}
+
+fs
+  .readdirSync(__dirname)
+  .filter(file => (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js'))
+  .forEach(file => {
+    const model = sequelize.import(path.join(__dirname, file));
+    db[model.name] = model;
+  });
+
+Object.keys(db).forEach(modelName => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;

--- a/src/server/models/score.js
+++ b/src/server/models/score.js
@@ -1,0 +1,16 @@
+
+
+module.exports = (sequelize, DataTypes) => {
+  const Score = sequelize.define('Score', {
+    player: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    score: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    }
+  }, {});
+
+  return Score;
+};

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,0 +1,10 @@
+const scoresController = require('../controllers').scores;
+
+module.exports = app => {
+  app.get('/api', (req, res) => res.status(200).send({
+    message: 'Welcome to the API!',
+  }));
+
+  app.post('/api/scores', scoresController.create);
+  app.get('/api/scores', scoresController.list);
+};


### PR DESCRIPTION
I've created an endpoint for saving player's score after the game, this is short documentation for it:

Create a score:

url: `POST /api/scores`
request body:
```
{
	"player": "Rob",
	"score": 123
}
```
response:
```
{
	"id": 1,
	"player": "Rob",
	"score": 123,
	"updatedAt": "2018-06-21T19:45:49.225Z",
	"createdAt": "2018-06-21T19:45:49.225Z"
}
```

Get scores:
url: `GET /api/scores`
response:
```
[{
		"id": 1,
		"player": "Rob",
		"score": 123,
		"updatedAt": "2018-06-21T19:45:49.225Z",
		"createdAt": "2018-06-21T19:45:49.225Z"
	}
]
```

To check it localy you will need to:
1. install postgres or use elephantsql.com
2. run db migration script with command: `sequelize db:migrate`

I was using this tutorial for a reference: https://scotch.io/tutorials/getting-started-with-node-express-and-postgres-using-sequelize